### PR TITLE
0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "attohttpc"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,10 +75,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -98,14 +123,12 @@ dependencies = [
 
 [[package]]
 name = "dedoc"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "attohttpc",
- "flate2",
- "html2text",
+ "html2md",
  "serde",
  "serde_json",
- "tar",
  "toiletcli",
 ]
 
@@ -135,18 +158,6 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
-
-[[package]]
-name = "filetime"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "windows-sys",
-]
 
 [[package]]
 name = "flate2"
@@ -219,16 +230,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "html2text"
-version = "0.6.0"
+name = "html2md"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cda84f06c1cc83476f79ae8e2e892b626bdadafcb227baec54c918cadc18a0"
+checksum = "be92446e11d68f5d71367d571c229d09ced1f24ab6d08ea0bff329d5f6c0b2a3"
 dependencies = [
  "html5ever",
- "markup5ever",
- "tendril",
- "unicode-width",
- "xml5ever",
+ "jni",
+ "lazy_static",
+ "markup5ever_rcdom",
+ "percent-encoding",
+ "regex",
 ]
 
 [[package]]
@@ -271,6 +283,26 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "lazy_static"
@@ -325,6 +357,24 @@ dependencies = [
  "string_cache_codegen",
  "tendril",
 ]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
+name = "memchr"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "miniz_oxide"
@@ -552,6 +602,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
 name = "rustix"
 version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +648,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -700,17 +788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +809,26 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -780,12 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +930,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -901,15 +1011,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "xattr"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "xml5ever"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "attohttpc"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,35 +66,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "coolor"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
-dependencies = [
- "crossterm",
-]
 
 [[package]]
 name = "core-foundation"
@@ -131,106 +97,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "dedoc"
 version = "0.2.0"
 dependencies = [
  "attohttpc",
- "html2md",
+ "html2text",
  "serde",
  "serde_json",
- "termimad",
  "toiletcli",
 ]
 
@@ -332,17 +205,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "html2md"
-version = "0.2.14"
+name = "html2text"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92446e11d68f5d71367d571c229d09ced1f24ab6d08ea0bff329d5f6c0b2a3"
+checksum = "74cda84f06c1cc83476f79ae8e2e892b626bdadafcb227baec54c918cadc18a0"
 dependencies = [
  "html5ever",
- "jni",
- "lazy_static",
- "markup5ever_rcdom",
- "percent-encoding",
- "regex",
+ "markup5ever",
+ "tendril",
+ "unicode-width",
+ "xml5ever",
 ]
 
 [[package]]
@@ -385,49 +257,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jni"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
-dependencies = [
- "cesu8",
- "combine",
- "jni-sys",
- "log",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "lazy-regex"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e723bd417b2df60a0f6a2b6825f297ea04b245d4ba52b5a22cb679bdf58b05fa"
-dependencies = [
- "lazy-regex-proc_macros",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "lazy-regex-proc_macros"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a1d9139f0ee2e862e08a9c5d0ba0470f2aa21cd1e1aa1b1562f83116c725f"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.32",
-]
 
 [[package]]
 name = "lazy_static"
@@ -484,60 +313,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "markup5ever_rcdom"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
-dependencies = [
- "html5ever",
- "markup5ever",
- "tendril",
- "xml5ever",
-]
-
-[[package]]
-name = "memchr"
-version = "2.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "minimad"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c4610f430e49b882fcaad0186134150d4d74fc76080b0a61f7000460c2e268"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys",
 ]
 
 [[package]]
@@ -757,35 +538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
-
-[[package]]
 name = "rustix"
 version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,15 +555,6 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -883,36 +626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,9 +633,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "string_cache"
@@ -997,42 +710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termimad"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2229aaf689febef17c66f4724bf84c52d3dade1fce12b1cdf4d9e409647ee253"
-dependencies = [
- "coolor",
- "crossbeam",
- "crossterm",
- "lazy-regex",
- "minimad",
- "serde",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"
@@ -1107,16 +784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "walkdir"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,15 +804,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +131,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "dedoc"
 version = "0.2.0"
 dependencies = [
@@ -129,6 +230,7 @@ dependencies = [
  "html2md",
  "serde",
  "serde_json",
+ "termimad",
  "toiletcli",
 ]
 
@@ -305,6 +407,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "lazy-regex"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e723bd417b2df60a0f6a2b6825f297ea04b245d4ba52b5a22cb679bdf58b05fa"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a1d9139f0ee2e862e08a9c5d0ba0470f2aa21cd1e1aa1b1562f83116c725f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,12 +502,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimad"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c4610f430e49b882fcaad0186134150d4d74fc76080b0a61f7000460c2e268"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -728,6 +883,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +997,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "termimad"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2229aaf689febef17c66f4724bf84c52d3dade1fce12b1cdf4d9e409647ee253"
+dependencies = [
+ "coolor",
+ "crossbeam",
+ "crossterm",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1076,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dedoc"
-version = "0.1.3"
+version = "0.2.0"
 description = "Terminal-based viewer for DevDocs documentation"
 authors = ["toiletbril"]
 readme = "README.md"
@@ -18,9 +18,7 @@ lto = true
 
 [dependencies]
 toiletcli = { version = "0.9.4", features = ["colors", "flags"] }
-html2text = { version = "0.6.0", features = ["ansi_colours"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"
 attohttpc = { version = "0.26.1", features = ["tls-native"] }
-flate2 = { version = "1.0.27", features = ["default", "rust_backend"] }
-tar = "0.4.40"
+html2md = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ lto = true
 
 [dependencies]
 toiletcli = { version = "0.9.4", features = ["colors", "flags"] }
+html2text = { version = "0.6.0", features = ["ansi_colours"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"
 attohttpc = { version = "0.26.1", features = ["tls-native"] }
-html2md = "0.2.14"
-termimad = "0.25.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"
 attohttpc = { version = "0.26.1", features = ["tls-native"] }
 html2md = "0.2.14"
+termimad = "0.25.2"

--- a/README.md
+++ b/README.md
@@ -12,15 +12,21 @@ pager or markdown reader.
 
 ## Usage
 
+Remember that running anything with `--help` prints a more detailed usage:
+ ```console
+ $ dedoc [subcommand] --help
+ ```
+
 To start using `dedoc` and fetch all latest available docsets, first run:
 ```console
 $ dedoc fetch
 Fetching `https://devdocs.io/docs.json`...
-Writing `docs.json`...
+Writing `/home/user/.dedoc/docs.json`...
 Fetching has successfully finished.
 ```
 
-You can use `-f` flag to overwrite the fetched document if you encounter any issues.
+You can use `-f` flag to overwrite the fetched document if you encounter any
+issues.
 
  To see available docsets, run:
 ```console
@@ -29,19 +35,26 @@ angular, ansible, apache_http_server, astro, async, ...
 ```
 
 Which will list all docsets available to download from file which you
-previously fetched. If you need version-specific docs, like
-`vue~3`/`~2`, use `-a` flag, which will list *everything*.
+previously fetched. If you need version-specific docs, like `vue~3`/`~2`, use
+`-a` flag, which will list *everything*.
+
+Using `-l` flag will show only local docsets, and `-n` will print each docset
+on a separate line.
 
 Download the documentation:
 ```console
 $ dedoc download rust
 Downloading `rust`...
-Received 9335861 of 9335861 bytes...
+Received 46313067 bytes, file 1 of 2...
+Received 3319078 bytes, file 2 of 2...
 Extracting to `/home/user/.dedoc/docsets/rust`...
+Unpacked 1899 files...
 Install has successfully finished.
 ```
 
 This will make the documentation available locally as a bunch of HTML pages.
+
+You can use `-f` flag here too to forcefully overwrite the documentation.
 
 To search, for instance, for `BufReader` from `rust`, run:
 ```console
@@ -49,47 +62,41 @@ $ dedoc search rust bufreader
 Searching for `bufreader`...
 Exact matches in `rust`:
    1  std/io/struct.bufreader
+         2  #method.borrow
+         3  #method.borrow_mut
+         4  #method.buffer
+         5  #method.by_ref
+         ...
 ```
 
-You will get search results which are pages with filenames that match your
-query. If you need a more thorough search, you can use `-p` flag, which will
-look inside of the files as well.
+You will get search results which are pages that match your query.
 
-Finally, to see the page you can either use `dedoc open`:
+Results that start with `#` denote fragments. Opening them will result in the
+output of only that specific fragment. Likewise, opening a page will show the
+entire page.
+
+For a more detailed search, use the `-p` flag. It makes search behave similarly
+to the `grep` command, and will look within all files, find all matches, and
+display them with some context around the found section.
+
+Use `-i` to perform case-insensitive search, and `-w` to search for the whole
+sentence.
+
+Finally, to see the page, you can either use `open`:
 ```console
 $ dedoc open rust std/io/struct.bufreader
 ```
 
-Or use `-o` flag, which will open n-th matched page:
+Or use `-o` flag with `search`, which will open n-th matched page or fragment:
 ```console
 $ dedoc search rust bufreader -o 1
 ```
 
-You would probably like to use `ss` instead of `search`, pipe output to a pager,
-like `less` and forcefully enable colors with `-c y` if your pager supports it,
-which turns the final command into:
+You would probably like to use `ss` instead of `search`, pipe output to a pager
+or markdown reader, like `less` and forcefully enable colors with `-c y`,
+turning the final command into:
 ```console
 $ dedoc -c y ss rust bufreader -o 1 | less -r
 ```
 
-## Help
-
-```console
-$ dedoc --help
-USAGE
-    dedoc <subcommand> [args]
-    Search DevDocs pages from terminal.
-
-SUBCOMMANDS
-    fetch, ft                       Fetch available docsets.
-    list, ls                        Show available docsets.
-    download, dl                    Download docsets.
-    remove, rm                      Delete docsets.
-    search, ss                      List pages that match your query.
-    open, op                        Display specified pages.
-
-OPTIONS
-    -c, --color <on/off/auto>       Use color when displaying output.
-    -v, --version                   Display version.
-        --help                      Display help message.
-```
+Happy coding!

--- a/TODO
+++ b/TODO
@@ -1,3 +1,5 @@
+* html to markdown transpiler =D
+
 * features for lowering binary size
 
 * interactive search

--- a/TODO
+++ b/TODO
@@ -1,3 +1,4 @@
+* fuzzy search
 * features for lowering binary size
 
 * interactive search

--- a/TODO
+++ b/TODO
@@ -1,6 +1,3 @@
-* html to markdown transpiler =D
-* use index.json
-
 * features for lowering binary size
 
 * interactive search

--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 * fuzzy search
-* jump to fragment
 
 * features to lower binary size
 

--- a/TODO
+++ b/TODO
@@ -1,4 +1,5 @@
 * html to markdown transpiler =D
+* use index.json
 
 * features for lowering binary size
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,6 @@
 * fuzzy search
 * jump to fragment
+* optimize cache
 
 * features to lower binary size
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,5 @@
 * fuzzy search
 * jump to fragment
-* optimize cache
 
 * features to lower binary size
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,7 @@
 * fuzzy search
-* features for lowering binary size
+* jump to fragment
+
+* features to lower binary size
 
 * interactive search
     * literally open a manpage out of html with own pager

--- a/src/common.rs
+++ b/src/common.rs
@@ -144,9 +144,9 @@ fn default_colour_map(annotation: &RichAnnotation) -> (String, String) {
     }
 }
 
-// Ideally, this should skipp right to header when printing the page out.
+// Ideally, this should skipp right to fragment when printing the page out.
 // This may not be possible without forking html2text ._.
-pub fn print_docset_file(path: PathBuf, _header: Option<&str>) -> ResultS {
+pub fn print_docset_file(path: PathBuf, _fragment: Option<&str>) -> ResultS {
     let file = File::open(&path)
         .map_err(|err| format!("Could not open `{}`: {err}", path.display()))?;
     let reader = BufReader::new(file);
@@ -170,7 +170,7 @@ pub fn print_page_from_docset(docset_name: &String, page: &String) -> ResultS {
         Err(format!("Invalid page: {page}"))
     }?;
 
-    let header = page_split.next();
+    let fragment = page_split.next();
 
     let page_path_string = docset_path.join(page_path)
         .display()
@@ -185,7 +185,7 @@ No page matching `{page}`. Did you specify the name from `search` correctly?"
         return Err(message);
     }
 
-    print_docset_file(page_path, header)
+    print_docset_file(page_path, fragment)
 }
 
 static mut HOME_DIR: Option<PathBuf> = None;
@@ -359,9 +359,9 @@ pub fn convert_paths_to_items(paths: Vec<PathBuf>, docset_name: &String) -> Resu
 
 pub fn print_search_results(search_results: &[String], mut start_index: usize) -> ResultS {
     for item in search_results {
-        if let Some(header_index) = item.rfind('#') {
+        if let Some(fragment_offset) = item.rfind('#') {
             // This may be wasteful, but it looks cool and trying to refactor cache made my head ache.
-            println!("{GRAY}{start_index:>4}{RESET}  {}{GRAY}, #{}", &item[..header_index], &item[header_index + 1..]);
+            println!("{GRAY}{start_index:>4}{RESET}  {}{GRAY}, #{}", &item[..fragment_offset], &item[fragment_offset + 1..]);
         } else {
             println!("{GRAY}{start_index:>4}{RESET}  {}", item);
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -107,15 +107,11 @@ pub fn print_md_file(path: PathBuf) -> ResultS {
     let file = File::open(&path)
         .map_err(|err| format!("Could not open `{}`: {err}", path.display()))?;
     let mut reader = BufReader::new(file);
-    let mut stdout = std::io::stdout();
-    let mut buffer = [0; 2048];
-    while let Ok(size) = reader.read(&mut buffer) {
-        if size == 0 {
-            break;
-        }
-        stdout.write_all(&buffer[..size])
-            .map_err(|err| format!("Unable to print file contents: {err}"))?;
-    }
+
+    let mut buffer = String::new();
+    let _ = reader.read_to_string(&mut buffer);
+
+    termimad::print_text(&buffer);
 
     Ok(())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -32,6 +32,7 @@ pub const BOLD:      Style = Style::Bold;
 pub const UNDERLINE: Style = Style::Underlined;
 pub const RESET:     Style = Style::Reset;
 
+// Print only in debug builds.
 #[macro_export]
 macro_rules! debug_println {
     ($($e:expr),+) => {{
@@ -57,6 +58,7 @@ pub struct Links {
     code: String,
 }
 
+// docs.json
 #[allow(dead_code)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Docs {
@@ -142,6 +144,8 @@ fn default_colour_map(annotation: &RichAnnotation) -> (String, String) {
     }
 }
 
+// Ideally, this should skipp right to header when printing the page out.
+// This may not be possible without forking html2text ._.
 pub fn print_docset_file(path: PathBuf, _header: Option<&str>) -> ResultS {
     let file = File::open(&path)
         .map_err(|err| format!("Could not open `{}`: {err}", path.display()))?;
@@ -187,6 +191,7 @@ No page matching `{page}`. Did you specify the name from `search` correctly?"
 static mut HOME_DIR: Option<PathBuf> = None;
 static HOME_DIR_INIT: Once = Once::new();
 
+// This is memoized, so every call after the first one is cheap.
 pub fn get_home_directory() -> Result<PathBuf, String> {
     unsafe {
         if let Some(home_dir) = HOME_DIR.as_ref() {
@@ -278,6 +283,7 @@ pub fn is_docs_json_old() -> Result<bool, String> {
     }
 }
 
+// This should be used to debug cryptic errors.
 pub fn write_to_logfile(message: impl Display) -> Result<PathBuf, String> {
     let log_file_path = get_program_directory()?.join("logs.txt");
 
@@ -299,6 +305,7 @@ pub enum SearchMatch {
     FoundVague(Vec<String>)
 }
 
+// Returns `true` when docset exists in `docs.json`, otherwise it will print a warning.
 pub fn is_docset_in_docs_or_print_warning(docset_name: &String, docs: &Vec<Docs>) -> bool {
     match is_docset_in_docs(docset_name, docs) {
         Some(SearchMatch::Found) => return true,
@@ -313,6 +320,7 @@ pub fn is_docset_in_docs_or_print_warning(docset_name: &String, docs: &Vec<Docs>
     false
 }
 
+// `exact` is perfect match, `vague` are files that contain `docset_name` in their path.
 pub fn is_docset_in_docs(docset_name: &String, docs: &Vec<Docs>) -> Option<SearchMatch> {
     let mut vague_matches = vec![];
 
@@ -332,6 +340,7 @@ pub fn is_docset_in_docs(docset_name: &String, docs: &Vec<Docs>) -> Option<Searc
     }
 }
 
+// Item is page filename without file extension.
 pub fn convert_paths_to_items(paths: Vec<PathBuf>, docset_name: &String) -> Result<Vec<String>, String> {
     let docset_path = get_docset_path(docset_name)?;
 
@@ -351,6 +360,7 @@ pub fn convert_paths_to_items(paths: Vec<PathBuf>, docset_name: &String) -> Resu
 pub fn print_search_results(search_results: &[String], mut start_index: usize) -> ResultS {
     for item in search_results {
         if let Some(header_index) = item.rfind('#') {
+            // This may be wasteful, but it looks cool and trying to refactor cache made my head ache.
             println!("{GRAY}{start_index:>4}{RESET}  {}{GRAY}, #{}", &item[..header_index], &item[header_index + 1..]);
         } else {
             println!("{GRAY}{start_index:>4}{RESET}  {}", item);

--- a/src/common.rs
+++ b/src/common.rs
@@ -350,7 +350,11 @@ pub fn convert_paths_to_items(paths: Vec<PathBuf>, docset_name: &String) -> Resu
 
 pub fn print_search_results(search_results: &[String], mut start_index: usize) -> ResultS {
     for item in search_results {
-        println!("{GRAY}{start_index:>4}{RESET}  {}", item);
+        if let Some(header_index) = item.rfind('#') {
+            println!("{GRAY}{start_index:>4}{RESET}  {}{GRAY}, #{}", &item[..header_index], &item[header_index + 1..]);
+        } else {
+            println!("{GRAY}{start_index:>4}{RESET}  {}", item);
+        }
         start_index += 1;
     }
     Ok(())

--- a/src/common.rs
+++ b/src/common.rs
@@ -120,6 +120,8 @@ pub fn print_md_file(path: PathBuf) -> ResultS {
     Ok(())
 }
 
+// @@@: this should check current settings (terminal width and color flags)
+// and compile intermediate markdown to just markdown.
 pub fn print_page_from_docset(docset_name: &String, page: &String) -> ResultS {
     let docset_path = get_docset_path(docset_name)?;
     let file_path = docset_path.join(page.to_owned() + ".md");

--- a/src/common.rs
+++ b/src/common.rs
@@ -336,33 +336,13 @@ pub fn is_docset_in_docs(docset_name: &String, docs: &Vec<Docs>) -> SearchMatch 
 }
 
 // Item is a filename without file extension.
-pub fn convert_paths_to_items(paths: Vec<PathBuf>, docset_name: &String) -> Result<Vec<String>, String> {
-    let docset_path = get_docset_path(docset_name)?;
+pub fn convert_path_to_item(path: PathBuf, docset_path: &PathBuf) -> Result<String, String> {
+    let item = path
+        .strip_prefix(&docset_path)
+        .map_err(|err| err.to_string())?;
+    let item = item.with_extension("");
 
-    let mut items = vec![];
-
-    for path in paths {
-        let item = path
-            .strip_prefix(&docset_path)
-            .map_err(|err| err.to_string())?;
-        let item = item.with_extension("");
-        items.push(item.display().to_string());
-    }
-
-    Ok(items)
-}
-
-pub fn print_search_results(search_results: &[String], mut start_index: usize) -> ResultS {
-    for item in search_results {
-        if let Some(fragment_offset) = item.rfind('#') {
-            // This may be wasteful, but it looks cool and trying to refactor cache made my head ache.
-            println!("{GRAY}{start_index:>4}{RESET}  {}{GRAY}, #{}", &item[..fragment_offset], &item[fragment_offset + 1..]);
-        } else {
-            println!("{GRAY}{start_index:>4}{RESET}  {}", item);
-        }
-        start_index += 1;
-    }
-    Ok(())
+    Ok(item.display().to_string())
 }
 
 pub fn get_local_docsets() -> Result<Vec<String>, String> {

--- a/src/download.rs
+++ b/src/download.rs
@@ -27,7 +27,7 @@ fn show_download_help() -> ResultS {
     Download a docset. Available docsets can be displayed using `list`.
 
 {GREEN}OPTIONS{RESET}
-    -f, --force                     Overwrite downloaded docsets.
+    -f, --force                     Force the download and overwrite files.
         --help                      Display help message."
     );
     Ok(())

--- a/src/download.rs
+++ b/src/download.rs
@@ -124,30 +124,15 @@ where
         let file_path = sanitize_filename_for_windows(file_path);
         let file_path = PathBuf::from(file_path);
 
-        let mut file_name = file_path.file_name()
-            .unwrap_or(file_path.as_os_str());
-
-        // Sometimes there's a weird file structure, that looks like
-        //      some_topic
-        //      └── index.html
-        //      another_topic
-        //      └── index.html
-        // I really don't like this, so this renames such "indexes" to their parent directory.
-        // If filename is not "index", just create the parent directories.
         if let Some(parent) = file_path.parent() {
-            if file_name == "index" && !parent.as_os_str().is_empty() {
-                file_name = parent.as_os_str();
-            }
-            if let Some(parent_of_parent) = parent.parent() {
-                create_dir_all(docset_path.join(parent_of_parent))
-                    .map_err(|err| format!("Could not create `{}`: {err}", parent.display()))?;
-            }
+            create_dir_all(docset_path.join(parent))
+                .map_err(|err| format!("Could not create `{}`: {err}", parent.display()))?;
         }
 
-        let mut file_name_html = file_name.to_owned();
-        file_name_html.push(".md");
+        let file_name_html = file_path.to_owned();
+        let file_name_md = file_name_html.with_extension("md");
 
-        let file_path = docset_path.join(file_name_html);
+        let file_path = docset_path.join(&file_name_md);
 
         let file = File::create(&file_path)
             .map_err(|err| format!("Could not create `{}`: {err}", file_path.display()))?;

--- a/src/download.rs
+++ b/src/download.rs
@@ -245,12 +245,6 @@ fn build_docset_from_db_json(
     remove_file(&db_json_path)
         .map_err(|err| format!("Could not remove `{}` after building {docset_name}: {err}", db_json_path.display()))?;
 
-    // Remove these files, since this version does not make use of it
-    let db_json_path = docset_path.join("db").with_extension("json");
-    let index_json_path = docset_path.join("index").with_extension("json");
-    remove_if_exists(&db_json_path)?;
-    remove_if_exists(&index_json_path)?;
-
     Ok(())
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -309,22 +309,22 @@ mod tests {
         <p id="what" class="hello">
             What
         </p>
-        <h1 class="heading">
+        <h1 class="heading" href="hello world">
             <h2 id="heading-in-a-heading">
                 What
             </h2>
-        </h1>
+        </h1 something="lol">
         "#;
 
         let should_be = r#"
         <p  >
             What
         </p>
-        <h1 >
+        <h1  href="hello world">
             <h2 >
                 What
             </h2>
-        </h1>
+        </h1 something="lol">
         "#;
 
         let result = sanitize_html_line(html_text.to_owned());

--- a/src/download.rs
+++ b/src/download.rs
@@ -271,6 +271,11 @@ where
     let mut successful_downloads = 0;
 
     while let Some(docset) = args_iter.next() {
+        // Don't print warnings when using with ls -n
+        if docset == "[downloaded]" {
+            continue;
+        }
+
         if !flag_force && is_docset_downloaded(docset)? {
             println!("\
 {YELLOW}WARNING{RESET}: Docset `{docset}` is already downloaded. \

--- a/src/download.rs
+++ b/src/download.rs
@@ -172,14 +172,14 @@ where
     {
         #[cfg(target_family = "windows")]
         let file_path = sanitize_filename_for_windows(file_path);
-        let mut file_path = PathBuf::from(file_path);
+        let file_path = PathBuf::from(file_path);
 
         if let Some(parent) = file_path.parent() {
             create_dir_all(docset_path.join(parent))
                 .map_err(|err| format!("Could not create `{}`: {err}", parent.display()))?;
         }
 
-        let mut file_name_html = file_path.as_mut_os_str().to_owned();
+        let mut file_name_html = file_path.as_os_str().to_owned();
         file_name_html.push(".html");
 
         let file_path = docset_path.join(&file_name_html);

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -24,7 +24,7 @@ fn show_fetch_help() -> ResultS {
     Fetch latest `docs.json` which lists available languages and frameworks.
 
 {GREEN}OPTIONS{RESET}
-    -f, --force                     Update even if `docs.json` is recent.
+    -f, --force                     Force the download and overwrite `docs.json`.
         --help                      Display help message."
     );
     Ok(())

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -13,7 +13,7 @@ use crate::common::{
     write_to_logfile,
 };
 use crate::common::{
-    BOLD, DEFAULT_DOCS_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION, YELLOW,
+    BOLD, DEFAULT_DOCS_JSON_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION, YELLOW,
 };
 
 fn show_fetch_help() -> ResultS {
@@ -33,10 +33,10 @@ fn show_fetch_help() -> ResultS {
 pub fn fetch_docs() -> Result<Vec<Docs>, String> {
     let user_agent = format!("{DEFAULT_USER_AGENT}/{VERSION}");
 
-    let response = get(DEFAULT_DOCS_LINK)
+    let response = get(DEFAULT_DOCS_JSON_LINK)
         .header_append("user-agent", user_agent)
         .send()
-        .map_err(|err| format!("Could not GET `{DEFAULT_DOCS_LINK}`: {err:?}"))?;
+        .map_err(|err| format!("Could not GET `{DEFAULT_DOCS_JSON_LINK}`: {err:?}"))?;
 
     let body = response
         .text()
@@ -91,7 +91,7 @@ Run `fetch --force` to ignore this warning."
         return Ok(());
     }
 
-    println!("Fetching `{DEFAULT_DOCS_LINK}`...");
+    println!("Fetching `{DEFAULT_DOCS_JSON_LINK}`...");
     let docs = fetch_docs()?;
 
     let program_path = get_program_directory()?;

--- a/src/list.rs
+++ b/src/list.rs
@@ -13,7 +13,7 @@ fn show_list_help() -> ResultS {
     Show available docsets.
 
 {GREEN}OPTIONS{RESET}
-    -l, --local                     Only show local docsets.
+    -l, --local                     Show only local docsets.
     -a, --all                       Show all version-specific docsets.
     -n, --newlines                  Print each docset on a separate line.
         --help                      Display help message."

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ where
         "ss" | "search"   => search(args),
         "op" | "open"     => open(args),
         other => {
-            Err(format!("Unknown subcommand `{other}`."))
+            Err(format!("Unknown subcommand `{other}`"))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,12 +50,12 @@ fn show_help() -> ResultS {
     Search DevDocs pages from terminal.
 
 {GREEN}SUBCOMMANDS{RESET}
-    {BOLD}fetch{RESET}{GRAY}, ft{RESET}                       Fetch available docsets.
-    {BOLD}list{RESET}{GRAY}, ls{RESET}                        Show available docsets.
-    {BOLD}download{RESET}{GRAY}, dl{RESET}                    Download docsets.
-    {BOLD}remove{RESET}{GRAY}, rm{RESET}                      Delete docsets.
-    {BOLD}search{RESET}{GRAY}, ss{RESET}                      List pages that match your query.
-    {BOLD}open{RESET}{GRAY}, op{RESET}                        Display specified pages.
+    fetch{GRAY}, ft{RESET}                       Fetch available docsets.
+    list{GRAY}, ls{RESET}                        Show available docsets.
+    download{GRAY}, dl{RESET}                    Download docsets.
+    remove{GRAY}, rm{RESET}                      Delete docsets.
+    search{GRAY}, ss{RESET}                      List pages that match your query.
+    open{GRAY}, op{RESET}                        Display specified pages.
 
 {GREEN}OPTIONS{RESET}
     -c, --color <on/off/auto>       Use color when displaying output.

--- a/src/open.rs
+++ b/src/open.rs
@@ -5,7 +5,7 @@ use toiletcli::flags::*;
 
 use crate::common::ResultS;
 use crate::common::{
-    deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_html_file
+    deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_md_file
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET};
 
@@ -40,7 +40,7 @@ where
 
     if flag_html {
         let path = PathBuf::from(args.join(" "));
-        return print_html_file(path);
+        return print_md_file(path);
     }
 
     let mut args = args.into_iter();

--- a/src/open.rs
+++ b/src/open.rs
@@ -5,7 +5,7 @@ use toiletcli::flags::*;
 
 use crate::common::ResultS;
 use crate::common::{
-    deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_md_file
+    deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_docset_file
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET};
 
@@ -40,7 +40,7 @@ where
 
     if flag_html {
         let path = PathBuf::from(args.join(" "));
-        return print_md_file(path);
+        return print_docset_file(path, None);
     }
 
     let mut args = args.into_iter();

--- a/src/open.rs
+++ b/src/open.rs
@@ -60,7 +60,7 @@ where
             return Err("No page specified. Try `open --help` for more information.".to_string());
         }
 
-        print_page_from_docset(&docset, &query)?;
+        print_page_from_docset(&docset, &query, None)?;
     }
 
     Ok(())

--- a/src/search.rs
+++ b/src/search.rs
@@ -38,6 +38,7 @@ fn show_search_help() -> ResultS {
 struct SearchFlags {
     case_insensitive: bool,
     precise: bool,
+    whole: bool
 }
 
 #[derive(Serialize, Deserialize, PartialEq)]
@@ -317,6 +318,7 @@ where
     let flags = SearchFlags {
         precise: flag_precise,
         case_insensitive: flag_case_insensitive,
+        whole: flag_whole,
     };
 
     if flag_open_is_empty {

--- a/src/search.rs
+++ b/src/search.rs
@@ -59,6 +59,7 @@ struct SearchCache<'a> {
     flags:         Cow<'a, SearchFlags>,
 }
 
+// @@@: don't read the whole cache before checking query.
 fn try_use_cache<'a>(docset: &'a String, query: &'a String, flags: &'a SearchFlags) -> Option<SearchCache<'a>> {
     let program_dir = get_program_directory().ok()?;
     let cache_path = program_dir.join("search_cache.json");

--- a/src/search.rs
+++ b/src/search.rs
@@ -120,7 +120,7 @@ pub fn search_docset_in_filenames(
 
     if !index_exists {
         let message = format!("\
-Index file does not exist. Dedoc docsets that were downloaded prior to `0.3.0` version did not use them. \
+Index file does not exist. Dedoc docsets that were downloaded prior to `0.2.0` version did not use them. \
 Please redownload the docset with `download {docset_name} --force`."
         );
         return Err(message);

--- a/src/search.rs
+++ b/src/search.rs
@@ -26,8 +26,8 @@ fn show_search_help() -> ResultS {
 
 {GREEN}OPTIONS{RESET}
     -i, --ignore-case               Ignore character case.
-    -p, --precise                   Search more thoroughly and look for mentions in other files.
-    -o, --open <number>             Open n-th search result.
+    -p, --precise                   Look inside files (like 'grep').
+    -o, --open <number>             Open n-th result.
         --help                      Display help message."
     );
     Ok(())

--- a/src/search.rs
+++ b/src/search.rs
@@ -126,12 +126,6 @@ Please redownload the docset with `download {docset_name} --force`."
         return Err(message);
     }
 
-    let query = if case_insensitive {
-        query.to_lowercase()
-    } else {
-        query.to_owned()
-    };
-
     let file = File::open(&index_json_path)
         .map_err(|err| format!("Could not open `{}`: {err}", index_json_path.display()))?;
 
@@ -142,9 +136,22 @@ Please redownload the docset with `download {docset_name} --force`."
 
     let mut items = vec![];
 
-    for entry in index.entries {
-        if entry.name.contains(&query) || entry.path.contains(&query) {
-            items.push(entry.path);
+    if case_insensitive {
+        let query = query.to_lowercase();
+
+        for entry in index.entries {
+            let name = entry.name.to_lowercase();
+            let path = entry.path.to_lowercase();
+
+            if name.contains(&query) || path.contains(&query) {
+                items.push(entry.path);
+            }
+        }
+    } else {
+        for entry in index.entries {
+            if entry.name.contains(query) || entry.path.contains(query) {
+                items.push(entry.path);
+            }
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -75,10 +75,10 @@ struct SearchCache<'a> {
 
 fn try_use_cache<'a>(search_options: &SearchOptions) -> Option<SearchCache<'a>> {
     let program_dir = get_program_directory().ok()?;
-    let cache_header_path = program_dir.join("search_cache_header.json");
+    let cache_options_path = program_dir.join("search_cache_options.json");
 
     {
-        let cache_options_file = File::open(cache_header_path).ok()?;
+        let cache_options_file = File::open(cache_options_path).ok()?;
         let cache_options_reader = BufReader::new(cache_options_file);
 
         let cached_search_options: SearchOptions = from_reader(cache_options_reader).ok()?;
@@ -105,7 +105,7 @@ fn cache_search_results(
     let program_dir = get_program_directory()?;
 
     {
-        let cache_options_path = program_dir.join("search_cache_header.json");
+        let cache_options_path = program_dir.join("search_cache_options.json");
         let cache_options_file = File::create(&cache_options_path)
             .map_err(|err| format!("Could not open cache options at `{}`: {err}", cache_options_path.display()))?;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,9 +11,8 @@ use toiletcli::flags::*;
 
 use crate::common::ResultS;
 use crate::common::{
-    convert_path_to_item, deserialize_docs_json, get_docset_path, get_program_directory,
-    is_docs_json_exists, is_docset_in_docs_or_print_warning, print_page_from_docset,
-    is_docset_downloaded
+    deserialize_docs_json, get_docset_path, get_program_directory, is_docs_json_exists,
+    is_docset_in_docs_or_print_warning, print_page_from_docset, is_docset_downloaded
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, GRAY, RESET, YELLOW, DOC_PAGE_EXTENSION};
 
@@ -42,14 +41,16 @@ pub struct VagueResult {
 }
 
 // Flags that change search result must be added here for cache to be updated.
-#[derive(Serialize, Deserialize, Default, PartialEq, Clone)]
+#[derive(Serialize, Deserialize)]
+#[derive(Default, PartialEq, Clone)]
 struct SearchFlags {
     case_insensitive: bool,
     precise: bool,
     whole: bool
 }
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[derive(PartialEq)]
 struct SearchCache<'a> {
     query:         Cow<'a, str>,
     docset:        Cow<'a, str>,
@@ -189,6 +190,16 @@ fn get_context(html_line: String, index: usize, word_len: usize) -> String {
 
 
     html_line[start_pos..end_pos].trim().to_owned()
+}
+
+// Item is a filename without file extension.
+pub fn convert_path_to_item(path: PathBuf, docset_path: &PathBuf) -> Result<String, String> {
+    let item = path
+        .strip_prefix(&docset_path)
+        .map_err(|err| err.to_string())?;
+    let item = item.with_extension("");
+
+    Ok(item.display().to_string())
 }
 
 type ExactMatches = Vec<String>;

--- a/src/search.rs
+++ b/src/search.rs
@@ -133,7 +133,7 @@ pub fn search_docset_in_filenames(
 
             let mut file_name = os_file_name.to_string_lossy().to_string();
 
-            if file_name.rfind(".html").is_none() {
+            if file_name.rfind(".md").is_none() {
                 continue;
             }
 
@@ -202,7 +202,7 @@ pub fn search_docset_thoroughly(
 
             let mut file_name = os_file_name.to_string_lossy().to_string();
 
-            if file_name.rfind(".html").is_none() {
+            if file_name.rfind(".md").is_none() {
                 continue;
             }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -491,7 +491,7 @@ where
             };
 
             let _ = cache_search_results(&search_options, &search_cache)
-                .map_err(|err| format!("{YELLOW}WARNING{RESET}: Could not write cache: {err}."));
+                .map_err(|err| println!("{YELLOW}WARNING{RESET}: Could not write cache: {err}."));
 
             (exact.into(), vague.into())
         };
@@ -542,7 +542,7 @@ where
             };
 
             let _ = cache_search_results(&search_options, &search_cache)
-                .map_err(|err| format!("{YELLOW}WARNING{RESET}: Could not write cache: {err}."));
+                .map_err(|err| println!("{YELLOW}WARNING{RESET}: Could not write cache: {err}."));
 
             exact.into()
         };

--- a/src/search.rs
+++ b/src/search.rs
@@ -123,7 +123,7 @@ pub fn search_docset_in_filenames(
 
     if !index_exists {
         let message = format!("\
-Index file does not exist. Dedoc docsets that were downloaded prior to `0.2.0` version did not use them. \
+Index file does not exist for `{docset_name}`. Docsets that were downloaded prior to version `0.2.0` are incompatible. \
 Please redownload the docset with `download {docset_name} --force`."
         );
         return Err(message);

--- a/src/search.rs
+++ b/src/search.rs
@@ -25,6 +25,7 @@ fn show_search_help() -> ResultS {
     List docset pages that match your query.
 
 {GREEN}OPTIONS{RESET}
+    -w, --whole                     Search for the whole sentence.
     -i, --ignore-case               Ignore character case.
     -p, --precise                   Look inside files (like 'grep').
     -o, --open <number>             Open n-th result.
@@ -260,12 +261,14 @@ where
     Args: Iterator<Item = String>,
 {
     let mut flag_help;
+    let mut flag_whole;
     let mut flag_precise;
     let mut flag_open;
     let mut flag_case_insensitive;
 
     let mut flags = flags![
         flag_help: BoolFlag,             ["--help"],
+        flag_whole: BoolFlag,            ["--whole", "-w"],
         flag_precise: BoolFlag,          ["--precise", "-p"],
         flag_open: StringFlag,           ["--open", "-o"],
         flag_case_insensitive: BoolFlag, ["--ignore-case", "-i"]
@@ -297,7 +300,17 @@ where
         return Ok(());
     }
 
-    let query = args.collect::<Vec<String>>().join(" ");
+    let query = {
+        let mut query = args.collect::<Vec<String>>().join(" ");
+        if flag_whole {
+            query.insert(0, ' ');
+            query.push(' ');
+            query
+        } else {
+            query
+        }
+    };
+
     let flag_open_is_empty = flag_open.is_empty();
     let open_number = flag_open.parse::<usize>().ok();
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -93,6 +93,7 @@ fn cache_search_results(
     Ok(())
 }
 
+// @@@: use index.json
 pub fn search_docset_in_filenames(
     docset_name: &String,
     query: &String,

--- a/src/search.rs
+++ b/src/search.rs
@@ -21,7 +21,7 @@ fn show_search_help() -> ResultS {
     println!(
         "\
 {GREEN}USAGE{RESET}
-    {BOLD}{PROGRAM_NAME} search{RESET} [-ipo] <docset> <query>
+    {BOLD}{PROGRAM_NAME} search{RESET} [-wipo] <docset> <query>
     List docset pages that match your query.
 
 {GREEN}OPTIONS{RESET}

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,6 +34,7 @@ fn show_search_help() -> ResultS {
     Ok(())
 }
 
+// Flags that change search result must be added here for cache to be updated.
 #[derive(Serialize, Deserialize, Default, PartialEq, Clone)]
 struct SearchFlags {
     case_insensitive: bool,


### PR DESCRIPTION
* `download` now only downloads `docs.json` and `index.json`. HTML pages are now generated directly out of `docs.json`, with unnecessary attributes stripped off for minimal disk usage.
* Default `search` now uses `index.json`, listing fragments when available.
* Opening a fragment with `search`/`open` now prints only the fragment contents.
* Precise `search` now provides contexts around the found section, similar to `grep`. Context may contain raw HTML, as currently files are transpiled on-the-fly for dynamic coloring support.
* Added `-w` to `search` (Search for the whole sentence).
* Search cache is now more efficient.
* `preformat` are now padded to 80 characters.
* Fixed minor bugs.