### PR TITLE
0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "dedoc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "attohttpc",
  "html2text",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,9 +691,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toiletcli"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ed45c3d66cc0f459d78743c66323ae4d92a99e1df62c3ceeaae61af897d48a"
+checksum = "5ca5f964dd0f2d9fc81b29c11356c659fa296c90d3ee31d1e167ada41ff496d4"
 dependencies = [
  "atty",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "html2text",
  "serde",
  "serde_json",
+ "terminal_size",
  "toiletcli",
 ]
 
@@ -672,6 +673,16 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ strip    = false
 debug    = true
 
 [dependencies]
-toiletcli  = { version = "0.9.4", default-features = false, features = ["colors", "flags"] }
+toiletcli  = { version = "0.10.0", default-features = false, features = ["colors", "flags"] }
 attohttpc  = { version = "0.26.1", default-features = false, features = ["tls"] }
 serde      = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.106"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "dedoc"
-version      = "0.2.1"
+version      = "0.2.2"
 description  = "Terminal-based viewer for DevDocs documentation"
 repository   = "https://github.com/toiletbril/dedoc"
 authors      = ["toiletbril"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ strip    = false
 debug    = true
 
 [dependencies]
-toiletcli  = { version = "0.10.0", default-features = false, features = ["colors", "flags"] }
-attohttpc  = { version = "0.26.1", default-features = false, features = ["tls"] }
-serde      = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.106"
-html2text  = "0.6.0"
+toiletcli     = { version = "0.10.0", default-features = false, features = ["colors", "flags"] }
+attohttpc     = { version = "0.26.1", default-features = false, features = ["tls"] }
+serde         = { version = "1.0.188", features = ["derive"] }
+serde_json    = "1.0.106"
+html2text     = "0.6.0"
+terminal_size = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ to the `grep` command, and will look within all files, find all matches, and
 display them with some context around the found section.
 
 Use `-i` to perform case-insensitive search, and `-w` to search for the whole
-sentence.
+sentence. If you want to forcefully print the entire page instead of only a
+fragment, use `-f` flag.
 
 Finally, to see the page, you can run `open` with the path with optional
 fragment:
@@ -113,10 +114,10 @@ $ dedoc search rust bufreader -o 2
 This will be as fast as `open`, due to search caching.
 
 You would probably like to use `ss` instead of `search`, pipe output to a pager
-or markdown reader, like `less` and forcefully enable colors for it with `-c
-y`, turning the final command into:
+or markdown reader, like `less` and forcefully enable colors for it with `-c`,
+turning the final command into:
 ```console
-$ dedoc -c y ss rust bufreader -o 2 | less -r
+$ dedoc -c ss rust bufreader -o 2 | less -r
 ```
 
 Happy coding!

--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ You will get search results which are pages that match your query.
 
 Results that start with `#` denote fragments. Opening them will result in the
 output of only that specific fragment. Likewise, opening a page will show the
-entire page.
+entire page. If you want to forcefully print the entire page instead of only a
+fragment, use `-f` flag.
 
 For a more detailed search, use the `-p` flag. It makes search behave similarly
 to the `grep` command, and will look within all files, find all matches, and
 display them with some context around the found section.
 
 Use `-i` to perform case-insensitive search, and `-w` to search for the whole
-sentence. If you want to forcefully print the entire page instead of only a
-fragment, use `-f` flag.
+sentence.
 
 Finally, to see the page, you can run `open` with the path with optional
 fragment:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # dedoc
 
-Search [DevDocs](https://devdocs.io/) from your terminal. Offline. **Without
-browser**. Without Python, Javascript or other inconveniences. Even without
-desktop environment.
+Search and view [DevDocs](https://devdocs.io/) from your terminal. Offline.
+**Without browser**. Without Python, Javascript or other inconveniences. Even
+without desktop environment.
 
 App directory is `~/.dedoc`. Docsets go into `~/.dedoc/docsets`.
 
@@ -16,8 +16,7 @@ $ cargo install dedoc
 ```
 
 Alternatively, precompiled `x86_64` binaries for Windows and Linux are
-available in 
-[Releases](https://github.com/toiletbril/dedoc/releases).
+available in [releases](https://github.com/toiletbril/dedoc/releases).
 
 ## Usage
 
@@ -95,6 +94,11 @@ Finally, to see the page, you can run `open` with the path with optional
 fragment:
 ```console
 $ dedoc open rust "std/io/struct.bufreader#method.borrow"
+...
+fn borrow(&self) -> &T
+Immutably borrows from an owned value. Read more
+source
+...
 ```
 
 Using `-h` with `open` makes `dedoc` interpret supplied arguments as a path to
@@ -103,16 +107,16 @@ HTML file and behave like a HTML to markdown transpiler.
 Instead of typing out the whole path, you can conveniently append `-o` flag the
 your previous `search` command, which will open n-th matched page or fragment:
 ```console
-$ dedoc search rust bufreader -o 1
+$ dedoc search rust bufreader -o 2
 ```
 
 This will be as fast as `open`, due to search caching.
 
 You would probably like to use `ss` instead of `search`, pipe output to a pager
-or markdown reader, like `less` and forcefully enable colors with `-c y`,
-turning the final command into:
+or markdown reader, like `less` and forcefully enable colors for it with `-c
+y`, turning the final command into:
 ```console
-$ dedoc -c y ss rust bufreader -o 1 | less -r
+$ dedoc -c y ss rust bufreader -o 2 | less -r
 ```
 
 Happy coding!

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ source
 ```
 
 Using `-h` with `open` makes `dedoc` interpret supplied arguments as a path to
-HTML file and behave like a HTML to markdown transpiler.
+HTML file and behave like a HTML to markdown transpiler. To make output wider or
+narrower, you can use `-c` flag with the number of columns.
 
 Instead of typing out the whole path, you can conveniently append `-o` flag the
 your previous `search` command, which will open n-th matched page or fragment:
@@ -111,7 +112,8 @@ your previous `search` command, which will open n-th matched page or fragment:
 $ dedoc search rust bufreader -o 2
 ```
 
-This will be as fast as `open`, due to search caching.
+This will be as fast as `open`, due to search caching. `-c` flag here works the
+same way as in `open`.
 
 You would probably like to use `ss` instead of `search`, pipe output to a pager
 or markdown reader, like `less` and forcefully enable colors for it with `-c`,

--- a/TODO
+++ b/TODO
@@ -1,6 +1,3 @@
-* when creating flags, swap long flags with short ones to make alignment cooler.
-* use r# for multiline strings
-
 * make good tests
 * fuzzy search
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,6 @@
+* when creating flags, swap long flags with short ones to make alignment cooler.
+* use r# for multiline strings
+
 * make good tests
 * fuzzy search
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,6 @@
 * make good tests
 * fuzzy search
+* print warnings after command output
 
 * transpile html to intermediate markdown when building docset with `download`
     * allow specifying default page width

--- a/TODO
+++ b/TODO
@@ -1,6 +1,5 @@
 * make good tests
 * fuzzy search
-* print warnings after command output
 
 * transpile html to intermediate markdown when building docset with `download`
     * allow specifying default page width

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, SystemTime};
 use html2text::render::text_renderer::{RichAnnotation, TaggedLine, TaggedString, TaggedLineElement::*};
 
 use toiletcli::colors::{Color, Style};
+use toiletcli::flags::{FlagError, FlagErrorType};
 
 use serde::{Deserialize, Serialize};
 
@@ -136,6 +137,14 @@ macro_rules! print_warning {
             eprintln!($($e),+);
         }
     };
+}
+
+pub(crate) fn get_flag_error(flag_error: &FlagError) -> String {
+    match flag_error.error_type {
+        FlagErrorType::CannotCombine => format!("Flag `{}` cannot be combined", flag_error.flag),
+        FlagErrorType::NoValueProvided => format!("No value provided for `{}` flag", flag_error.flag),
+        FlagErrorType::Unknown => format!("Unknown flag `{}`", flag_error.flag),
+    }
 }
 
 #[inline]

--- a/src/common.rs
+++ b/src/common.rs
@@ -408,8 +408,7 @@ pub(crate) fn create_program_directory() -> ResultS {
 const WEEK: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 
 pub(crate) fn is_docs_json_old() -> Result<bool, String> {
-    let program_path = get_program_directory()
-        .map_err(|err| err.to_string())?;
+    let program_path = get_program_directory()?;
 
     let metadata = program_path
         .join("docs.json")

--- a/src/common.rs
+++ b/src/common.rs
@@ -128,6 +128,16 @@ pub(crate) fn deserialize_docs_json() -> Result<Vec<Docs>, String> {
     Ok(docs)
 }
 
+#[macro_export]
+macro_rules! print_warning {
+    ($($e:expr),+) => {
+        {
+            eprint!("{}WARNING{}: ", toiletcli::colors::Color::Yellow, toiletcli::colors::Style::Reset);
+            eprintln!($($e),+);
+        }
+    };
+}
+
 #[inline]
 pub(crate) fn split_to_item_and_fragment(path: String) -> Result<(String, Option<String>), String> {
     let mut path_split = path.split('#');
@@ -307,7 +317,7 @@ pub(crate) fn print_docset_file(path: PathBuf, fragment: Option<&String>) -> Res
     Ok(is_fragment_found)
 }
 
-pub(crate) fn print_page_from_docset(docset_name: &String, page: &String, fragment: Option<&String>) -> Result<bool, String> {
+pub(crate) fn print_page_from_docset(docset_name: &str, page: &str, fragment: Option<&String>) -> Result<bool, String> {
     let docset_path = get_docset_path(docset_name)?;
 
     let page_path_string = docset_path.join(page)
@@ -450,10 +460,10 @@ pub(crate) fn is_docset_in_docs_or_print_warning(docset_name: &String, docs: &[D
             let end_index = std::cmp::min(3, vague_matches.len());
             let first_three = &vague_matches[..end_index];
 
-            println!("{YELLOW}WARNING{RESET}: Unknown docset `{docset_name}`. Did you mean `{}`?", first_three.join("`/`"));
+            print_warning!("Unknown docset `{docset_name}`. Did you mean `{}`?", first_three.join("`/`"));
         }
         SearchMatch::None => {
-            println!("{YELLOW}WARNING{RESET}: Unknown docset `{docset_name}`. Did you run `fetch`?");
+            print_warning!("Unknown docset `{docset_name}`. Did you run `fetch`?");
         }
     }
     false
@@ -521,7 +531,7 @@ pub(crate) fn is_docs_json_exists() -> Result<bool, String> {
 }
 
 #[inline]
-pub(crate) fn get_docset_path(docset_name: &String) -> Result<PathBuf, String> {
+pub(crate) fn get_docset_path(docset_name: &str) -> Result<PathBuf, String> {
     let docsets_path = get_program_directory()?.join("docsets");
     Ok(docsets_path.join(docset_name))
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -35,7 +35,7 @@ fn show_download_help() -> ResultS {
 
 fn download_db_and_index_json_with_progress(
     docset_name: &String,
-    docs: &Vec<Docs>,
+    docs: &[Docs],
 ) -> ResultS {
     let user_agent = format!("{DEFAULT_USER_AGENT}/{VERSION}");
 
@@ -89,7 +89,7 @@ fn download_db_and_index_json_with_progress(
 }
 
 // Remove class="...", title="...", data-language="..." attributes from HTML tags to reduce size.
-fn sanitize_html_line<'a>(html_line: String) -> String {
+fn sanitize_html_line(html_line: String) -> String {
     enum State {
         Default,
         InTag,
@@ -105,9 +105,9 @@ fn sanitize_html_line<'a>(html_line: String) -> String {
     let mut state = State::Default;
     let mut position = 0;
 
-    let mut html_line_chars = html_line.chars();
+    let html_line_chars = html_line.chars();
 
-    while let Some(ch) = html_line_chars.next() {
+    for ch in html_line_chars {
         match state {
             State::Default => {
                 if ch == '<' {
@@ -219,7 +219,7 @@ impl<'de> Visitor<'de> for FileVisitor {
         M: MapAccess<'de>,
     {
         build_docset_from_map_with_progress(&self.docset_name, map)
-            .map_err(|err| Error::custom(format!("{err}")))?;
+            .map_err(|err| Error::custom(format!("Error while building `{}`: {err}", self.docset_name)))?;
         Ok(())
     }
 }
@@ -227,7 +227,7 @@ impl<'de> Visitor<'de> for FileVisitor {
 fn build_docset_from_db_json(
     docset_name: &String,
 ) -> ResultS {
-    let docset_path = get_docset_path(&docset_name)?;
+    let docset_path = get_docset_path(docset_name)?;
     let db_json_path = docset_path
         .join("db")
         .with_extension("json");
@@ -270,10 +270,9 @@ where
 
     let docs = deserialize_docs_json()?;
 
-    let mut args_iter = args.iter();
     let mut successful_downloads = 0;
 
-    while let Some(docset) = args_iter.next() {
+    for docset in args.iter() {
         // Don't print warnings when using with ls -n
         if docset == "[downloaded]" {
             continue;
@@ -285,23 +284,21 @@ where
 If you still want to update it, re-run this command with `--force`"
             );
             continue;
-        } else {
-            if is_docset_in_docs_or_print_warning(docset, &docs) {
-                println!("Downloading `{docset}`...");
-                download_db_and_index_json_with_progress(docset, &docs)?;
+        } else if is_docset_in_docs_or_print_warning(docset, &docs) {
+            println!("Downloading `{docset}`...");
+            download_db_and_index_json_with_progress(docset, &docs)?;
 
-                println!("Extracting to `{}`...", get_docset_path(docset)?.display());
-                build_docset_from_db_json(docset)?;
+            println!("Extracting to `{}`...", get_docset_path(docset)?.display());
+            build_docset_from_db_json(docset)?;
 
-                successful_downloads += 1;
-            }
+            successful_downloads += 1;
         }
     }
 
-    if successful_downloads > 1 {
-        println!("{BOLD}{successful_downloads} items were successfully installed{RESET}.");
-    } else if successful_downloads == 1 {
-        println!("{BOLD}Install has successfully finished{RESET}.");
+    match successful_downloads {
+        0   => {}
+        1   => println!("{BOLD}Install has successfully finished{RESET}."),
+        _   => println!("{BOLD}{successful_downloads} items were successfully installed{RESET}."),
     }
 
     Ok(())

--- a/src/download.rs
+++ b/src/download.rs
@@ -13,7 +13,7 @@ use toiletcli::flags::*;
 use crate::common::{Docs, ResultS};
 use crate::common::{
     deserialize_docs_json, get_docset_path, is_docs_json_exists, is_docset_downloaded,
-    is_docset_in_docs_or_print_warning
+    is_docset_in_docs_or_print_warning, get_flag_error
 };
 use crate::common::{
     BOLD, DEFAULT_DB_JSON_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION
@@ -21,8 +21,7 @@ use crate::common::{
 use crate::print_warning;
 
 fn show_download_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} download{RESET} [-f] <docset1> [docset2, ..]
     Download a docset. Available docsets can be displayed using `list`.
@@ -254,15 +253,16 @@ pub(crate) fn download<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_force;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag,  ["--help"],
-        flag_force: BoolFlag, ["--force", "-f"]
+        flag_force: BoolFlag, ["-f", "--force"],
+        flag_help: BoolFlag,  ["--help"]
     ];
 
-    let args = parse_flags(&mut args, &mut flags)?;
+    let args = parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
     if flag_help || args.is_empty() { return show_download_help(); }
 
     if !is_docs_json_exists()? {

--- a/src/download.rs
+++ b/src/download.rs
@@ -16,8 +16,9 @@ use crate::common::{
     is_docset_in_docs_or_print_warning
 };
 use crate::common::{
-    BOLD, DEFAULT_DB_JSON_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION, YELLOW,
+    BOLD, DEFAULT_DB_JSON_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION
 };
+use crate::print_warning;
 
 fn show_download_help() -> ResultS {
     println!(
@@ -151,7 +152,7 @@ fn sanitize_html_line(html_line: String) -> String {
     sanitized_line
 }
 
-fn build_docset_from_map_with_progress<'de, M>(docset_name: &String, mut map: M) -> ResultS
+fn build_docset_from_map_with_progress<'de, M>(docset_name: &str, mut map: M) -> ResultS
 where
     M: MapAccess<'de>,
 {
@@ -279,9 +280,9 @@ where
         }
 
         if !flag_force && is_docset_downloaded(docset)? {
-            println!("\
-{YELLOW}WARNING{RESET}: Docset `{docset}` is already downloaded. \
-If you still want to update it, re-run this command with `--force`"
+            print_warning!(
+                "Docset `{docset}` is already downloaded. \
+                If you still want to update it, re-run this command with `--force`"
             );
             continue;
         } else if is_docset_in_docs_or_print_warning(docset, &docs) {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -10,15 +10,14 @@ use toiletcli::flags::*;
 use crate::common::{Docs, ResultS};
 use crate::common::{
     create_program_directory, get_program_directory, is_docs_json_exists, is_docs_json_old,
-    write_to_logfile,
+    write_to_logfile, get_flag_error
 };
 use crate::common::{
     BOLD, DEFAULT_DOCS_JSON_LINK, DEFAULT_USER_AGENT, GREEN, PROGRAM_NAME, RESET, VERSION, YELLOW,
 };
 
 fn show_fetch_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} fetch{RESET} [-f]
     Fetch latest `docs.json` which lists available languages and frameworks.
@@ -70,17 +69,18 @@ pub(crate) fn fetch<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_force;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag,  ["--help"],
-        flag_force: BoolFlag, ["--force", "-f"]
+        flag_force: BoolFlag, ["-f", "--force"],
+        flag_help: BoolFlag,  ["--help"]
     ];
 
-    parse_flags(&mut args, &mut flags)?;
-    if flag_help { return show_fetch_help(); }
+    parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
 
+    if flag_help { return show_fetch_help(); }
     if !flag_force && is_docs_json_exists()? && !is_docs_json_old()? {
         let message = format!(
             "\

--- a/src/list.rs
+++ b/src/list.rs
@@ -74,7 +74,7 @@ where
 
     while let Some(entry) = docs_names_peekable.next() {
         // slug has ~ if it's version-specific
-        if !flag_local && !flag_all && entry.contains("~") {
+        if !flag_local && !flag_all && entry.contains('~') {
             continue;
         }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -2,7 +2,7 @@ use toiletcli::flags;
 use toiletcli::flags::*;
 
 use crate::common::ResultS;
-use crate::common::{deserialize_docs_json, get_local_docsets, is_docs_json_exists};
+use crate::common::{deserialize_docs_json, get_local_docsets, is_docs_json_exists, get_flag_error};
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET};
 
 fn show_list_help() -> ResultS {
@@ -25,19 +25,20 @@ pub(crate) fn list<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_all;
     let mut flag_local;
     let mut flag_newlines;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag,     ["--help"],
-        flag_all: BoolFlag,      ["--all", "-a"],
-        flag_local: BoolFlag,    ["--local", "-l"],
-        flag_newlines: BoolFlag, ["--newlines", "-n"]
+        flag_all: BoolFlag,      ["-a", "--all"],
+        flag_local: BoolFlag,    ["-l", "--local"],
+        flag_newlines: BoolFlag, ["-n", "--newlines"],
+        flag_help: BoolFlag,     ["--help"]
     ];
 
-    parse_flags(&mut args, &mut flags)?;
+    parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
     if flag_help { return show_list_help(); }
 
     if !is_docs_json_exists()? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use list::list;
 use fetch::fetch;
 
 #[cfg(debug_assertions)]
-use test::test_c;
+use test::debug_test;
 
 fn show_version() -> ResultS {
     #[cfg(debug_assertions)]
@@ -110,7 +110,7 @@ where
         "ss" | "search"   => search(args),
         "op" | "open"     => open(args),
         #[cfg(debug_assertions)]
-        "test"            => test_c(args),
+        "test"            => debug_test(args),
         other => {
             Err(format!("Unknown subcommand `{other}`"))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,13 @@ where
     let mut flag_version;
     let mut flag_help;
     let mut flag_color;
+    let mut flag_color_force;
 
     let mut flags = flags![
-        flag_help: BoolFlag,    ["--help"],
-        flag_version: BoolFlag, ["--version", "-v"],
-        flag_color: StringFlag, ["--color", "-c"]
+        flag_help: BoolFlag,        ["--help"],
+        flag_version: BoolFlag,     ["--version", "-v"],
+        flag_color: StringFlag,     ["--color"],
+        flag_color_force: BoolFlag, ["-c"]
     ];
 
     let subcommand = parse_flags_until_subcommand(&mut args, &mut flags)?
@@ -91,9 +93,9 @@ where
 
     if !flag_color.is_empty() {
         match flag_color.as_str() {
-            "y" | "yes" | "on"  | "always" => unsafe { overwrite_should_use_colors(true) }
-            "n" | "no"  | "off" | "never"  => unsafe { overwrite_should_use_colors(false) }
-            "auto" | "tty" => {}
+            _ if flag_color_force => unsafe { overwrite_should_use_colors(true) }
+            "y" | "yes" | "on"    => unsafe { overwrite_should_use_colors(true) }
+            "n" | "no"  | "off"   => unsafe { overwrite_should_use_colors(false) }
             other => {
                 return Err(format!("Argument `{other}` for `--color <on/off/auto>` is invalid."));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use toiletcli::flags;
 mod common;
 
 use common::ResultS;
+use common::get_flag_error;
 use common::{BOLD, UNDERLINE, GREEN, GRAY, PROGRAM_NAME, RED, RESET, VERSION};
 
 mod open;
@@ -34,8 +35,7 @@ fn show_version() -> ResultS {
     let version = format!("{VERSION} debug build");
     #[cfg(not(debug_assertions))]
     let version = VERSION;
-    println!(
-        "\
+    println!("\
 dedoc {version}
 (c) toiletbril <{UNDERLINE}https://github.com/toiletbril{RESET}>
 
@@ -47,8 +47,7 @@ There is NO WARRANTY, to the extent permitted by law."
 }
 
 fn show_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME}{RESET} <subcommand> [args]
     Search DevDocs pages from terminal.
@@ -62,7 +61,8 @@ fn show_help() -> ResultS {
     open{GRAY}, op{RESET}                        Display specified pages.
 
 {GREEN}OPTIONS{RESET}
-    -c, --color <on/off/auto>       Use color when displaying output.
+    -c  --force-colors              Forcefully enable colors.
+        --color <on/off/auto>       Control output colors.
     -v, --version                   Display version.
         --help                      Display help message."
     );
@@ -77,18 +77,19 @@ where
     debug_println!("Run `test` to perform tests.");
 
     let mut flag_version;
-    let mut flag_help;
     let mut flag_color;
     let mut flag_color_force;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag,        ["--help"],
-        flag_version: BoolFlag,     ["--version", "-v"],
+        flag_version: BoolFlag,     ["-v", "--version"],
+        flag_color_force: BoolFlag, ["-c", "--force-colors"],
         flag_color: StringFlag,     ["--color"],
-        flag_color_force: BoolFlag, ["-c"]
+        flag_help: BoolFlag,        ["--help"]
     ];
 
-    let subcommand = parse_flags_until_subcommand(&mut args, &mut flags)?
+    let subcommand = parse_flags_until_subcommand(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?
         .to_lowercase();
 
     if !flag_color.is_empty() {

--- a/src/open.rs
+++ b/src/open.rs
@@ -6,13 +6,12 @@ use toiletcli::flags::*;
 use crate::common::ResultS;
 use crate::common::{
     deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_docset_file,
-    split_to_item_and_fragment, is_docs_json_exists
+    split_to_item_and_fragment, is_docs_json_exists, get_flag_error
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET};
 
 fn show_open_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} open{RESET} [-h] <docset> <page>
     Print a page. Pages can be searched using `search`.
@@ -28,15 +27,16 @@ pub(crate) fn open<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_html;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag, ["--help"],
-        flag_html: BoolFlag, ["--html", "-h"]
+        flag_html: BoolFlag, ["-h", "--html"],
+        flag_help: BoolFlag, ["--help"]
     ];
 
-    let args = parse_flags(&mut args, &mut flags)?;
+    let args = parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
     if flag_help || args.is_empty() { return show_open_help(); }
 
 

--- a/src/open.rs
+++ b/src/open.rs
@@ -6,18 +6,20 @@ use toiletcli::flags::*;
 use crate::common::ResultS;
 use crate::common::{
     deserialize_docs_json, is_docset_in_docs_or_print_warning, print_page_from_docset, print_docset_file,
-    split_to_item_and_fragment, is_docs_json_exists, get_flag_error
+    split_to_item_and_fragment, is_docs_json_exists, get_flag_error, get_terminal_width
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET};
+use crate::print_warning;
 
 fn show_open_help() -> ResultS {
     println!("\
 {GREEN}USAGE{RESET}
-    {BOLD}{PROGRAM_NAME} open{RESET} [-h] <docset> <page>
+    {BOLD}{PROGRAM_NAME} open{RESET} [-hc] <docset> <page>
     Print a page. Pages can be searched using `search`.
 
 {GREEN}OPTIONS{RESET}
     -h, --html                      Interpret arguments as a path to HTML file and translate it to markdown.
+    -c, --columns                   Make output N columns wide.
         --help                      Display help message."
     );
     Ok(())
@@ -28,21 +30,35 @@ where
     Args: Iterator<Item = String>,
 {
     let mut flag_html;
+    let mut flag_columns;
     let mut flag_help;
 
     let mut flags = flags![
-        flag_html: BoolFlag, ["-h", "--html"],
-        flag_help: BoolFlag, ["--help"]
+        flag_html: BoolFlag,      ["-h", "--html"],
+        flag_columns: StringFlag, ["-c", "--columns"],
+        flag_help: BoolFlag,      ["--help"]
     ];
 
     let args = parse_flags(&mut args, &mut flags)
         .map_err(|err| get_flag_error(&err))?;
     if flag_help || args.is_empty() { return show_open_help(); }
 
+    let mut width = get_terminal_width();
+
+    let maybe_columns = flag_columns.parse::<usize>().ok();
+    if let Some(col_number) = maybe_columns {
+        if col_number == 0 {
+            width = 999;
+        } else if col_number > 10 {
+            width = col_number;
+        }
+    } else if !flag_columns.is_empty() {
+        print_warning!("Invalid number of columns.");
+    }
 
     if flag_html {
         let path = PathBuf::from(args.join(" "));
-        print_docset_file(path, None)?;
+        print_docset_file(path, None, width)?;
         return Ok(());
     }
 
@@ -69,7 +85,7 @@ where
 
         let (item, fragment) = split_to_item_and_fragment(query)?;
 
-        print_page_from_docset(&docset, &item, fragment.as_ref())?;
+        print_page_from_docset(&docset, &item, fragment.as_ref(), width)?;
     }
 
     Ok(())

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -4,13 +4,12 @@ use toiletcli::flags;
 use toiletcli::flags::*;
 
 use crate::common::ResultS;
-use crate::common::{get_docset_path, is_docset_downloaded, get_local_docsets};
+use crate::common::{get_docset_path, is_docset_downloaded, get_local_docsets, get_flag_error};
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET, YELLOW};
 use crate::print_warning;
 
 fn show_remove_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} remove{RESET} <docset1> [docset2, ...]
     Delete a docset. Only docsets downloaded by {PROGRAM_NAME} can be removed.
@@ -46,15 +45,16 @@ pub(crate) fn remove<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_purge_all;
+    let mut flag_help;
 
     let mut flags = flags![
         flag_help: BoolFlag,      ["--help"],
         flag_purge_all: BoolFlag, ["--purge-all"]
     ];
 
-    let args = parse_flags(&mut args, &mut flags)?;
+    let args = parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
 
     if flag_purge_all {
         let local_docsets = get_local_docsets()?;

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -6,6 +6,7 @@ use toiletcli::flags::*;
 use crate::common::ResultS;
 use crate::common::{get_docset_path, is_docset_downloaded, get_local_docsets};
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, RESET, YELLOW};
+use crate::print_warning;
 
 fn show_remove_help() -> ResultS {
     println!(
@@ -70,7 +71,7 @@ where
 
     for docset in args.iter() {
         if !is_name_allowed(docset) {
-            println!("{YELLOW}WARNING{RESET}: `{docset}` contains forbidden characters.");
+            print_warning!("`{docset}` contains forbidden characters.");
             continue;
         }
 
@@ -82,7 +83,7 @@ where
                     .map_err(|err| format!("Unable to remove `{}`: {err}", docset_path.display()))?;
             }
         } else {
-            println!("{YELLOW}WARNING{RESET}: `{docset}` is not installed.");
+            print_warning!("{YELLOW}WARNING{RESET}: `{docset}` is not installed.");
         }
     }
 

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -26,15 +26,17 @@ fn is_name_allowed<S: AsRef<str>>(docset_name: &S) -> bool {
 
     let has_slashes = {
         #[cfg(target_family = "windows")]
-        { docset.find("\\").is_some() || docset.find("/").is_some() }
+        { docset.contains('\\') || docset.contains('/') }
 
         #[cfg(target_family = "unix")]
-        { docset.find("/").is_some() }
+        { docset.contains('/') }
     };
+
     let starts_with_tilde = docset.starts_with('~');
-    let has_dollars = docset.find('$').is_some();
     let starts_with_dot = docset.starts_with('.');
-    let has_dots = docset.find("..").is_some();
+
+    let has_dollars = docset.contains('$');
+    let has_dots = docset.contains("..");
 
     !(has_slashes || starts_with_tilde || has_dollars || starts_with_dot || has_dots)
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -229,7 +229,7 @@ fn get_context_around_query(html_line: &String, index: usize, query_len: usize) 
 // Item is a file path without a file extension which is relative to docset directory
 fn convert_path_to_item(path: PathBuf, docset_path: &PathBuf) -> Result<String, String> {
     let item = path
-        .strip_prefix(&docset_path)
+        .strip_prefix(docset_path)
         .map_err(|err| err.to_string())?
         .with_extension("")
         .display()
@@ -260,7 +260,7 @@ fn search_docset_precisely(
         let mut exact_files   = vec![];
         let mut vague_results = vec![];
 
-        let dir = read_dir(&path)
+        let dir = read_dir(path)
             .map_err(|err| format!("Could not read `{}` directory: {err}", path.display()))?;
 
         for entry in dir {
@@ -275,7 +275,7 @@ fn search_docset_precisely(
 
             if file_type.is_dir() {
                 let (mut exact, mut vague) =
-                    visit_dir_with_query(original_path, &entry.path(), &query, case_insensitive)?;
+                    visit_dir_with_query(original_path, &entry.path(), query, case_insensitive)?;
 
                 exact_files.append(&mut exact);
                 vague_results.append(&mut vague);

--- a/src/search.rs
+++ b/src/search.rs
@@ -13,15 +13,15 @@ use toiletcli::flags::*;
 use crate::common::ResultS;
 use crate::common::{
     deserialize_docs_json, get_docset_path, get_program_directory, is_docs_json_exists,
-    is_docset_in_docs_or_print_warning, print_page_from_docset, is_docset_downloaded, split_to_item_and_fragment
+    is_docset_in_docs_or_print_warning, print_page_from_docset, is_docset_downloaded,
+    split_to_item_and_fragment, get_flag_error
 };
 use crate::common::{BOLD, GREEN, PROGRAM_NAME, LIGHT_GRAY, GRAY, GRAYER, GRAYEST,
                     RESET, DOC_PAGE_EXTENSION};
 use crate::print_warning;
 
 fn show_search_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} search{RESET} [-wipof] <docset> <query>
     List docset pages that match your query.
@@ -533,27 +533,30 @@ pub(crate) fn search<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_whole;
     let mut flag_precise;
     let mut flag_open;
     let mut flag_case_insensitive;
     let mut flag_ignore_fragment;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag,             ["--help"],
-        flag_whole: BoolFlag,            ["--whole", "-w"],
-        flag_precise: BoolFlag,          ["--precise", "-p"],
-        flag_open: StringFlag,           ["--open", "-o"],
-        flag_case_insensitive: BoolFlag, ["--ignore-case", "-i"],
-        flag_ignore_fragment: BoolFlag,  ["--ignore-fragment", "-f"]
+        flag_whole: BoolFlag,            ["-w", "--whole"],
+        flag_precise: BoolFlag,          ["-p", "--precise"],
+        flag_open: StringFlag,           ["-o", "--open"],
+        flag_case_insensitive: BoolFlag, ["-i", "--ignore-case"],
+        flag_ignore_fragment: BoolFlag,  ["-f", "--ignore-fragment"],
+        flag_help: BoolFlag,             ["--help"]
     ];
 
-    let args = parse_flags(&mut args, &mut flags)?;
+    let args = parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
+
     if flag_help { return show_search_help(); }
 
     if !is_docs_json_exists()? {
-        return Err("The list of available documents has not yet been downloaded. Please run `fetch` first.".to_string());
+        return Err("\
+The list of available documents has not yet been downloaded. Please run `fetch` first.".to_string());
     }
 
     let mut args = args.into_iter();

--- a/src/search.rs
+++ b/src/search.rs
@@ -398,6 +398,8 @@ fn print_search_results(search_results: &[ExactResult], mut start_index: usize) 
 
 fn search_impl(
     search_options: SearchOptions,
+    // Passing this as a String is needed to check if output was not numeric
+    // before parsing it as number
     flag_open: String
 ) -> Result<Vec<String>, String> {
     let mut warnings = vec![];
@@ -407,7 +409,7 @@ fn search_impl(
     let open_number = flag_open.parse::<usize>().ok();
 
     if open_number.is_none() {
-        // Printing query is needed to let you know if you messed up any flags
+        // This lets you know whether flag messed up your query
         println!("Searching for `{}`...", search_options.query);
     }
 
@@ -582,6 +584,7 @@ where
         flags:  Cow::Borrowed(&search_flags),
     };
 
+    // Print warnings only after search results
     let warnings = search_impl(search_options, flag_open)?;
 
     for warning in warnings {

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,7 +34,7 @@ fn show_test_help() -> ResultS {
     Ok(())
 }
 
-fn create_args<'a>(args: &'a str) -> IntoIter<String> {
+fn create_args(args: &str) -> IntoIter<String> {
     args.split_whitespace()
         .map(|s| s.to_string())
         .collect::<Vec<String>>()
@@ -76,7 +76,7 @@ fn test_search_should_use_cache(args: &str) {
 
     {
         let cache_options_path = program_directory.join("search_cache_options.json");
-        let cache_options_file = File::open(&cache_options_path).unwrap();
+        let cache_options_file = File::open(cache_options_path).unwrap();
         let cache_options_reader = BufReader::new(cache_options_file);
 
         let cached_search_options: SearchOptions = serde_json::from_reader(cache_options_reader).unwrap();
@@ -125,7 +125,7 @@ where
 
     debug_println!("Performing search tests...");
 
-    let search_results = vec![
+    let search_results = [
         run_with_args(search, "backbone -o 1", "open first page"),
         run_with_args(search, "backbone -o 100", "open 100th page"),
         run_with_args(search, "backbone -i collection-at", "list search results in correct casing"),

--- a/src/test.rs
+++ b/src/test.rs
@@ -89,7 +89,7 @@ fn test_search_should_use_cache(args: &str) {
 
 // Manual testing. I think this way is better than integration testing I came up with initially.
 // If everything is looking cool, then it's we should be fine :3
-pub(crate) fn test_c<Args>(mut args: Args) -> ResultS
+pub(crate) fn debug_test<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {

--- a/src/test.rs
+++ b/src/test.rs
@@ -34,13 +34,6 @@ fn show_test_help() -> ResultS {
     Ok(())
 }
 
-fn create_args(args: &str) -> IntoIter<String> {
-    args.split_whitespace()
-        .map(|s| s.to_string())
-        .collect::<Vec<String>>()
-        .into_iter()
-}
-
 fn reset_state_and_cache() {
     debug_println!("Removing cache...");
 
@@ -51,6 +44,13 @@ fn reset_state_and_cache() {
     let _ = remove_file(program_directory.join("search_cache.json"));
 }
 
+fn create_args(args: &str) -> IntoIter<String> {
+    args.split_whitespace()
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>()
+        .into_iter()
+}
+
 fn run_with_args<O>(
     command: fn(IntoIter<String>) -> Result<O, String>,
     args_str: &str, should_do: &str
@@ -59,7 +59,6 @@ fn run_with_args<O>(
     debug_println!("Running with args: `{args_str}`, should {should_do}");
 
     let command_result = command(args);
-
     if let Err(err) = &command_result {
         debug_println!("{BOLD}*** Test failed with: {err} ***");
         false

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,7 +6,7 @@ use std::io::BufReader;
 use std::vec::IntoIter;
 
 use crate::common::ResultS;
-use crate::common::get_program_directory;
+use crate::common::{get_program_directory, get_flag_error};
 use crate::common::{RED, GREEN, BOLD, RESET, PROGRAM_NAME};
 use crate::debug_println;
 
@@ -21,8 +21,7 @@ use toiletcli::flags::{FlagType, parse_flags};
 use toiletcli::flags;
 
 fn show_test_help() -> ResultS {
-    println!(
-        "\
+    println!("\
 {GREEN}USAGE{RESET}
     {BOLD}{PROGRAM_NAME} test{RESET} [-f] <docset> <page>
     Run the testing suite.
@@ -92,17 +91,18 @@ pub(crate) fn debug_test<Args>(mut args: Args) -> ResultS
 where
     Args: Iterator<Item = String>,
 {
-    let mut flag_help;
     let mut flag_full;
+    let mut flag_help;
 
     let mut flags = flags![
-        flag_help: BoolFlag, ["--help"],
-        flag_full: BoolFlag, ["-f", "--full"]
+        flag_full: BoolFlag, ["-f", "--full"],
+        flag_help: BoolFlag, ["--help"]
     ];
 
-    let args = parse_flags(&mut args, &mut flags)?;
-    if flag_help { return show_test_help(); }
+    let args = parse_flags(&mut args, &mut flags)
+        .map_err(|err| get_flag_error(&err))?;
 
+    if flag_help { return show_test_help(); }
     if flag_full {
         reset_state_and_cache();
 


### PR DESCRIPTION
* `open` and `search` now open fragments based on the terminal width, up to 120 columns. 
* Added `-c` to `open` and `search` to choose width.
* Added `-f` to `open` and `search` to ignore the fragment and instead open the entire page.
* Fixed clippy warnings.
* Fixed minor bugs.