### PR TITLE
fix!: follow OS path-specs with dirs::data_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,14 +95,36 @@ dependencies = [
 
 [[package]]
 name = "dedoc"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "attohttpc",
+ "dirs",
  "html2text",
  "serde",
  "serde_json",
  "terminal_size",
  "toiletcli",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -267,6 +289,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.0",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +439,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -522,6 +561,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -680,7 +739,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ serde         = { version = "1.0.188", features = ["derive"] }
 serde_json    = "1.0.106"
 html2text     = "0.11.0"
 terminal_size = "0.3.0"
+dirs          = "5.0.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -369,57 +369,10 @@ No page matching `{page}`. Did you specify the name from `search` correctly?"
     print_docset_file(page_path, fragment, width)
 }
 
-static mut HOME_DIR: Option<PathBuf> = None;
-static HOME_DIR_INIT: Once = Once::new();
-
-pub(crate) fn get_home_directory() -> Result<PathBuf, String> {
-    unsafe {
-        if let Some(home_dir) = HOME_DIR.as_ref() {
-            return Ok(home_dir.clone());
-        }
-    }
-
-    fn internal() -> Result<PathBuf, String> {
-        #[cfg(target_family = "unix")]
-        let home = std::env::var("HOME");
-
-        #[cfg(target_family = "windows")]
-        let home = std::env::var("userprofile");
-
-        if let Ok(home) = home {
-            Ok(home.into())
-        } else {
-            let user = std::env::var("USER").map_err(|err| err.to_string())?;
-
-            #[cfg(target_family = "unix")]
-            let home = format!("/home/{user}");
-
-            #[cfg(target_family = "windows")]
-            let home = format!("C:\\Users\\{user}");
-
-            Ok(home.into())
-        }
-    }
-
-    let home_path = internal()?;
-
-    if home_path.is_dir() {
-        unsafe {
-            HOME_DIR_INIT.call_once(|| {
-                HOME_DIR = Some(home_path.clone());
-            });
-        }
-        Ok(home_path)
-    } else {
-        Err("Could not figure out home directory".to_string())
-    }
-}
-
 #[inline]
 pub(crate) fn get_program_directory() -> Result<PathBuf, String> {
-    let path = get_home_directory()?;
-    let dot_program = format!(".{PROGRAM_NAME}");
-    let program_path = path.join(dot_program);
+    let data_dir : PathBuf = dirs::data_dir().unwrap();
+    let program_path = data_dir.join(PROGRAM_NAME);
     Ok(program_path)
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Uses dirs::data_dir to use directories compliant with OS path specifications instead of using `$HOME/.dedoc`

ref: #8